### PR TITLE
SHOP-1: update README with bootstrapping instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # Simple E-Commerce Shopping Cart
+
+## Boot Section
+To get started with the development environment:
+1. Clone the repository.
+2. Run `docker-compose up -d`.
+3. Follow further instructions in the `docs` folder.


### PR DESCRIPTION
Context:
- The README lacked clear instructions for setting up the development environment.

Changes:
- Added a "Boot Section" detailing how to clone the repository and use `docker-compose`.
- Redirected users to additional instructions in the `docs` folder.

Testing:
- No code changes to test; documentation updated only.

Refs: N/A
SemVer: none