### PR TITLE
SHOP-3: add docker setup with nginx and php

### DIFF
--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,0 +1,19 @@
+server {
+    listen 80;
+    index index.php index.html;
+    error_log  /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
+    root /var/www/html/public;
+
+    location ~ \.php$ {
+        fastcgi_pass php:9000;
+        fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        include fastcgi_params;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+        gzip_static on;
+    }
+}

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,0 +1,30 @@
+FROM php:8.4-fpm
+
+# Set working directory
+WORKDIR /var/www/html
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    libpng-dev \
+    libonig-dev \
+    libxml2-dev \
+    zip \
+    unzip \
+    libicu-dev
+
+# Clear cache
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install PHP extensions
+RUN docker-php-ext-install pdo_mysql mbstring intl bcmath exif pcntl gd
+
+# Get latest Composer
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+# Set working directory back to /var/www/html
+WORKDIR /var/www/html
+
+EXPOSE 9000
+CMD ["php-fpm"]

--- a/src/public/index.php
+++ b/src/public/index.php
@@ -1,0 +1,1 @@
+﻿<?php phpinfo();


### PR DESCRIPTION
Context:
- The project lacked the necessary Docker configuration for serving PHP applications with Nginx.

Changes:
- Added Nginx configuration in `docker/nginx/default.conf`.
- Created a PHP Dockerfile in `docker/php/Dockerfile` to run PHP-FPM.
- Configured PHP with required extensions like `pdo_mysql`, `mbstring`, `intl`, and others.
- Added a basic PHP file (`src/public/index.php`) for testing PHP setup with Nginx.

Testing:
- Verified Nginx and PHP containers functionality by serving and rendering the `phpinfo()` page.

Refs: N/A
SemVer: minor